### PR TITLE
Explain renewal, expiration and proactive license requests

### DIFF
--- a/10-General.inc.md
+++ b/10-General.inc.md
@@ -161,6 +161,8 @@ When configuring a [=DRM system=] to decrypt content using multiple [=content ke
 
 Note: In theory, it is possible for the [=DRM system=] initialization data to be the same for different [=content keys=]. In practice, the `default_KID` is often included in the initialization data so this is unlikely. Nevertheless, DASH clients cannot assume that using equal initialization data implies anything about equality of the [=DRM system configuration=] or the [=content key=] - the `default_KID` is the factor identifying the scope in which a single [=content key=] is to be used. See [[#CPS-default_KID]].
 
+The [=DRM system configuration=] MAY change over time, both due to MPD updates in live services and due to runtime changes in the [=solution-specific logic and configuration=]. A typical example of runtime changse would be using a unique license server URL for each license request.
+
 ## Signaling presence of encrypted content ## {#CPS-mpd-scheme}
 
 The presence of a `ContentProtection` descriptor with `schemeIdUri="urn:mpeg:dash:mp4protection:2011"` on an adaptation set informs a DASH client that all representations in the adaptation set are encrypted in conformance to Common Encryption ([[!DASH]] sections 5.8.4.1 and 5.8.5.2 and [[!CENC]] section 11) and require a [=DRM system=] to provide access.


### PR DESCRIPTION
Adding relevant explanations in response to #4, discussion in last task force call and related email threads.

From what I understand, the way it works is that some CDMs (e.g. Widevine) raise the EME “license-renewal” event when they want to renew a license (at a CDM-determined point). Other CDMs (e.g. PlayReady) don’t do that and just say “license expired – I have to stop playing now” when the time comes, expecting the app to care for things like obtaining new licenses.

We should support both of the above and also the scenario where we the license server URL is different for each renewal. I suggest the following mechanism:

1.	Typical app is expected to observe the EME license expiration date (there is an “expiration” timestamp exposed) and to proactively acquire licenses in advance unless this behavior is disabled by solution-specific logic.
    *	This soluition-specific logic would be e.g. “I know that my Widevine CDM is handling renewals on its own and I will just wait for the license-renewal event”
2.	The “license-renewal” event is not a part of the primary DRM workflows but an optional external signal that informs the app on what its solution-specific logic must do.
3.	The decisions and values provided by soluition-specific logic are allowed to change over time (e.g. the license server URL can change every time the CDM raises license-renewal event).

This way we keep the main workflows generic enough to work with any DRM in the basic case, while accepting the Widevine specific renewal process as valid custom logic.


Fixes #4